### PR TITLE
Stop scanning rocks servers if exact match found

### DIFF
--- a/src/luarocks/search.lua
+++ b/src/luarocks/search.lua
@@ -223,6 +223,18 @@ function search.search_repos(query, lua_version)
             end
          end
       end
+
+      -- stop searching repos if exact match was found
+      local query_version = nil
+      for _, constraint in pairs(query.constraints) do
+         if constraint.op == '==' then
+            query_version = constraint.version.string
+            break
+         end
+      end
+      if results[query.name] and results[query.name][query_version] ~= nil then
+         break
+      end
    end
    -- search through rocks in cfg.rocks_provided
    local provided_repo = "provided by VM or rocks_provided"


### PR DESCRIPTION
A customer configured two rocks servers:
1. offline (`file:///path/to/rocks`)
2. and default online (`rocks.tarantool.org`)

He tries to do `rocks install http 1.0.5-1`.

Online server is unavailable due to his local network policy, but the rock is available offline.
Despite anything, luarocks still tries to fetch manifest online, which results in 30 sec hang since network access is restricted. 

This patch aborts scanning when exact match is found