### PR TITLE
Fix zero values in ziptime

### DIFF
--- a/src/luarocks/tools/zip.lua
+++ b/src/luarocks/tools/zip.lua
@@ -306,7 +306,7 @@ end
 
 
 local function ziptime_to_luatime(ztime, zdate)
-   return {
+   local date = {
       year = shr(zdate, 9) + 1980,
       month = shr(lowbits(zdate, 9), 5),
       day = lowbits(zdate, 5),
@@ -314,6 +314,11 @@ local function ziptime_to_luatime(ztime, zdate)
       min = shr(lowbits(ztime, 11), 5),
       sec = lowbits(ztime, 5) * 2,
    }
+
+   if date.month == 0 then date.month = 1 end
+   if date.day == 0 then date.day = 1 end
+
+   return date
 end
 
 local function read_file_in_zip(zh, cdr)


### PR DESCRIPTION
Now the time in the packed rocks with zlib is zeros. This creates errors when trying to set such a time in the file using touch.
Setting the correct time is simply not written and is in `#TODO` in function:
```lua
local function zipwriter_open_new_file_in_zip(self, filename)
   if self.in_open_file then
      self:close_file_in_zip()
      return nil
   end
   local lfh = {}
   self.local_file_header = lfh
   lfh.last_mod_file_time = 0 -- TODO
   lfh.last_mod_file_date = 0 -- TODO
   lfh.file_name_length = #filename
   lfh.extra_field_length = 0
   lfh.file_name = filename:gsub("\\", "/")
   lfh.external_attr = shl(493, 16) -- TODO proper permissions
   self.in_open_file = true
   return true
end
```

And if we meet the rock packed in this way, the easiest way is to check the dates at 0 in function:

```lua
local function ziptime_to_luatime(ztime, zdate)
   local date = {
      year = shr(zdate, 9) + 1980,
      month = shr(lowbits(zdate, 9), 5),
      day = lowbits(zdate, 5),
      hour = shr(ztime, 11),
      min = shr(lowbits(ztime, 11), 5),
      sec = lowbits(ztime, 5) * 2,
   }

   if date.month == 0 then date.month = 1 end
   if date.day == 0 then date.day = 1 end

   return date
end
```