### PR TITLE
luarocks: prefers an interpreter from the luarocks configuration

### DIFF
--- a/src/luarocks/cmd.lua
+++ b/src/luarocks/cmd.lua
@@ -382,7 +382,11 @@ local function get_config_text(cfg)  -- luacheck: ignore 431
 
    buf = buf.."\n   Configuration files:\n"
    local conf = cfg.config_files
-   buf = buf.."      System  : "..show_status(fs.absolute_name(conf.system.file), conf.system.found).."\n"
+   if not cfg.variables.FORCE_HARDCODED then
+      buf = buf.."      System  : "..show_status(fs.absolute_name(conf.system.file), conf.system.found).."\n"
+   else
+      buf = buf.."      System  : disabled in this LuaRocks installation.\n"
+   end
    if conf.user.file then
       buf = buf.."      User    : "..show_status(fs.absolute_name(conf.user.file), conf.user.found).."\n"
    else
@@ -589,6 +593,9 @@ function cmd.run_command(description, commands, external_namespace, ...)
    -- Now that the config is fully loaded, reinitialize fs using the full
    -- feature set.
    fs.init()
+   if cfg.variables.FORCE_HARDCODED and cfg.variables.LUA then
+      lua_found = true
+   end
 
    -- if the Lua interpreter wasn't explicitly found before cfg.init,
    -- try again now.

--- a/src/luarocks/core/cfg.lua
+++ b/src/luarocks/core/cfg.lua
@@ -634,6 +634,7 @@ function cfg.init(detected, warning)
 
    -- Use detected values as defaults, overridable via config files or CLI args
 
+   hardcoded.LUA = dir.path(hardcoded.LUA_BINDIR,hardcoded.LUA_INTERPRETER)
    local hardcoded_lua = hardcoded.LUA
    local hardcoded_lua_dir = hardcoded.LUA_DIR
    local hardcoded_lua_bindir = hardcoded.LUA_BINDIR
@@ -740,10 +741,14 @@ function cfg.init(detected, warning)
       exit_ok, exit_err, exit_what = nil, err, "config"
    end
 
+   if hardcoded.FORCE_HARDCODED then
+      util.deep_merge(cfg.variables, hardcoded)
+   end
+
    -- Load user configuration file (if allowed)
    local home_config_ok
    local project_config_ok
-   if not hardcoded.FORCE_CONFIG then
+   if not hardcoded.FORCE_CONFIG and not hardcoded.FORCE_HARDCODED then
       local env_var   = "LUAROCKS_CONFIG_" .. cfg.lua_version:gsub("%.", "_")
       local env_value = os.getenv(env_var)
       if not env_value then


### PR DESCRIPTION
Since there is a need to use the tarantool interpreter instead of lua,
 a couple of changes were made to apply the FORCE_HARDCODED flag,
 which allows you to use tarantool as an interpreter even if
 there is a luarocks config.

Needed for [tt issue #919](https://github.com/tarantool/tt/issues/919)